### PR TITLE
Fixing issue RDF4J-26 (ensuring context are not null) and tests

### DIFF
--- a/marklogic-rdf4j-functionaltests/src/test/java/com/marklogic/rdf4j/functionaltests/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-rdf4j-functionaltests/src/test/java/com/marklogic/rdf4j/functionaltests/MarkLogicRepositoryConnectionTest.java
@@ -22,24 +22,28 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.iteration.IteratorIteration;
+import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.BooleanQuery;
@@ -206,7 +210,6 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		deleteDB(dbName);
 		deleteRESTUser("reader");
 		deleteRESTUser("writer");
-
 	}
 
 	@Before
@@ -1353,7 +1356,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 
 		Assert.assertTrue(testWriterCon.hasStatement(st1, false));
 		Assert.assertFalse(testWriterCon.hasStatement(st1, false, (Resource)null));
-		Assert.assertFalse(testWriterCon.hasStatement(st1, false, null));
+	//	Assert.assertFalse(testWriterCon.hasStatement(st1, false, null));
 		Assert.assertTrue(testWriterCon.hasStatement(st1, false, dirgraph));
 
 
@@ -1432,7 +1435,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 	@Test
 	public void testPrepareQuery1() throws Exception {
 		testAdminCon.add(MarkLogicRepositoryConnectionTest.class.getResourceAsStream(TEST_DIR_PREFIX + "companies_100.ttl"), "",
-				RDFFormat.TURTLE, null);
+				RDFFormat.TURTLE,(Resource) null);
 		Assert.assertEquals(testAdminCon.size(), 1600L);
 
 		StringBuilder queryBuilder = new StringBuilder(128);
@@ -1477,7 +1480,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 	public void testPrepareQuery2() throws Exception{
 
 		Reader ir = new BufferedReader(new InputStreamReader(MarkLogicRepositoryConnectionTest.class.getResourceAsStream(TEST_DIR_PREFIX + "property-paths.ttl")));
-		testAdminCon.add(ir, "", RDFFormat.TURTLE, null);
+		testAdminCon.add(ir, "", RDFFormat.TURTLE, (Resource)null);
 
 		StringBuilder queryBuilder = new StringBuilder(128);
 		queryBuilder.append(" prefix : <http://learningsparql.com/ns/papers#> ");
@@ -2139,7 +2142,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		Assert.assertFalse(testWriterCon.isEmpty());
 		Assert.assertTrue("The graph gr2 should not be empty", (testWriterCon.size(gr2) == 2));
 		Assert.assertTrue("The graph gr2 should not be empty", (testAdminCon.size(gr2) == 2));
-		Assert.assertTrue("The default graph should  be empty", (testAdminCon.size(null) == 0));
+		//Assert.assertTrue("The default graph should  be empty", (testAdminCon.size(null) == 0));
 
 		testWriterCon.prepareUpdate(
 				" DROP GRAPH <http://ml.com> ").execute();
@@ -2348,8 +2351,8 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		Statement st2 = vf.createStatement(john, lname, johnlname);
 		assertThat(testAdminCon.hasStatement(st2, false,  dirgraph), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(st2, true,  null, dirgraph), is(equalTo(true)));
-		assertThat(testAdminCon.hasStatement(st2, true,  null), is(equalTo(false)));
-		assertThat(testAdminCon.hasStatement(john, lname, johnlname, true,  null), is(equalTo(false)));
+		assertThat(testAdminCon.hasStatement(st2, true, (Resource) null), is(equalTo(false)));
+		assertThat(testAdminCon.hasStatement(john, lname, johnlname, true,  (Resource)null), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(john, lname, johnlname, true,  (Resource)null, dirgraph, dirgraph1), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(st2, true), is(equalTo(true)));
 		testAdminCon.remove(st2, dirgraph);
@@ -2360,7 +2363,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		testAdminCon.remove(john,email, null);
 		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false,  dirgraph), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false), is(equalTo(true)));
-		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false, null), is(equalTo(false)));
+		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false, (Resource)null), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false, null, dirgraph), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(john, lname, johnlname, false,  dirgraph), is(equalTo(false)));
 		testAdminCon.remove(john,null,null);
@@ -2369,9 +2372,9 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false,  dirgraph), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(john, fname, johnfname, false, null, dirgraph), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(john, lname, johnlname, false, (Resource)null, dirgraph), is(equalTo(false)));
-		assertThat(testAdminCon.hasStatement(micah, homeTel, johnhomeTel, false, null), is(equalTo(false)));
+		assertThat(testAdminCon.hasStatement(micah, homeTel, johnhomeTel, false, null, null), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(micah, homeTel, micahhomeTel, false, (Resource)null), is(equalTo(true)));
-		assertThat(testAdminCon.hasStatement(micah, homeTel, micahhomeTel, false, null), is(equalTo(true)));
+		assertThat(testAdminCon.hasStatement(micah, homeTel, micahhomeTel, false, null, (Resource)null), is(equalTo(true)));
 
 		testAdminCon.remove((Resource)null, homeTel,(Value) null);
 		testAdminCon.remove((Resource)null, homeTel, (Value)null);
@@ -2394,7 +2397,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		testAdminCon.remove(null, null, micahlname);
 		assertThat(testAdminCon.hasStatement(micah, fname, micahfname, false), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(micah, fname, micahfname, false, null, dirgraph), is(equalTo(true)));
-		assertThat(testAdminCon.hasStatement(null, null, null, false, null), is(equalTo(true)));
+		assertThat(testAdminCon.hasStatement(null, null, null, false, null, null), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(null, null, null, false), is(equalTo(true)));
 		assertThat(testAdminCon.hasStatement(null, null, null, false, dirgraph), is(equalTo(false)));
 		assertThat(testAdminCon.hasStatement(micah, fname, micahfname, false, dirgraph1, dirgraph), is(equalTo(false)));
@@ -2621,7 +2624,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 			Assert.assertEquals("Size of repository must be 6",6, testAdminCon.size(dirgraph,dirgraph1));
 			Assert.assertEquals("Size of repository must be 3",3, testAdminCon.size(dirgraph,null));
 			Assert.assertEquals("Size of repository must be 3",3, testAdminCon.size(dirgraph1,null));
-			Assert.assertEquals("Size of default graph must be 0",0, testAdminCon.size(null));
+			Assert.assertEquals("Size of default graph must be 0",0, testAdminCon.size(null,null));
 
 
 			testAdminCon.add(dirgraph, vf.createIRI("http://TYPE"), vf.createLiteral("Directory Graph"));
@@ -2637,7 +2640,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 				testAdminCon.rollback();
 		}
 		Assert.assertEquals("Size of repository must be 4",4, testAdminCon.size(dirgraph1,null));
-		Assert.assertEquals(1, testAdminCon.size(null));
+		Assert.assertEquals(1, testAdminCon.size((Resource)null));
 		Assert.assertEquals(1, testAdminCon.size(null, null));
 		Assert.assertEquals(3, testAdminCon.size(dirgraph, dirgraph));
 
@@ -2677,7 +2680,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 
 
 		// Check handling of getStatements with null context
-		result = testAdminCon.getStatements(null, null, null, false, null);
+		result = testAdminCon.getStatements(null, null, null, false, null, null);
 		assertThat(result, is(notNullValue()));
 		try {
 			while (result.hasNext()) {
@@ -2704,7 +2707,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		assertNotNull("List should not be null", list);
 		assertFalse("List should not be empty", list.isEmpty());
 
-		List<Statement> list1 = Iterations.addAll(testAdminCon.getStatements(dirgraph, null, null, false, null),
+		List<Statement> list1 = Iterations.addAll(testAdminCon.getStatements(dirgraph, null, null, false, (Resource)null),
 				new ArrayList<Statement>());
 		assertNotNull("List should not be null", list1);
 		assertFalse("List should not be empty", list1.isEmpty());
@@ -2719,7 +2722,7 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		IRI ur = vf.createIRI("http://abcd");
 
 
-		CloseableIteration<? extends Statement, RepositoryException> iter1 = testAdminCon.getStatements(null, null, null, false, null);
+		CloseableIteration<? extends Statement, RepositoryException> iter1 = testAdminCon.getStatements(null, null, null, false, null, null);
 
 		try {
 			int count = 0;
@@ -3731,4 +3734,166 @@ public class MarkLogicRepositoryConnectionTest extends ConnectedRESTQA {
 		Assert.assertEquals("Size of dirgraph1",0, testAdminCon.size());
 
 	}
+   
+   @Ignore
+  	public void testHasStatement()
+  		throws Exception
+  	{
+  		try{
+  			BNode somenode = SimpleValueFactory.getInstance().createBNode();
+  			
+  			testAdminCon.add(john, fname, somenode, dirgraph);
+  			testAdminCon.add(john, fname, somenode, null);
+  			
+  			
+  			Assert.assertTrue(testAdminCon.hasStatement(john, fname, somenode, false, dirgraph));
+  			Assert.assertTrue(testAdminCon.hasStatement(john, fname, somenode, false, null));
+  			
+
+  		}
+  		catch(Exception e){
+  			e.printStackTrace();
+
+  		}
+  	}
+   @Ignore
+	public void testExportStatements() throws Exception{
+
+		Statement st1 = vf.createStatement(john, fname, johnfname, dirgraph);
+		Statement st2 = vf.createStatement(john, homeTel, johnhomeTel, dirgraph1);
+
+		testAdminCon.add(st1);
+		testAdminCon.add(st2);
+		testAdminCon.add(micah, lname, micahlname, (Resource)null);
+
+
+		try{
+			Assert.assertEquals(3, testAdminCon.size());
+			
+			testWriterCon.exportStatements(null, null, null, false, new AbstractRDFHandler() {
+
+				@Override
+				public void handleStatement(Statement st)
+					throws RDFHandlerException
+				{
+					if(st.getContext() == null){
+						assertThat(st, is((equalTo(vf.createStatement(micah, lname, micahlname, null)))));
+					}
+					else {
+						if(st.getContext().equals(dirgraph)){
+							assertThat(st, is((equalTo(st1))));
+						}
+						else if(st.getContext().equals(dirgraph1)){
+							assertThat(st, is((equalTo(st2))));
+						}
+					
+						else{
+							fail("Statement not returned");
+						}
+					}
+					
+				}
+			},dirgraph, dirgraph1, null);
+			
+			testWriterCon.exportStatements(null, null, null, false, new AbstractRDFHandler() {
+
+				@Override
+				public void handleStatement(Statement st)
+					throws RDFHandlerException
+				{
+					if(st.getContext() == null){
+						assertThat(st, is((equalTo(vf.createStatement(micah, lname, micahlname, null)))));
+					}
+					else {
+						if(st.getContext().equals(dirgraph)){
+							assertThat(st, is((equalTo(st1))));
+						}
+									
+						else{
+							fail("Statement not returned");
+						}
+					}
+					
+				}
+			},dirgraph,  null);
+			testWriterCon.exportStatements(null, null, null, false, new AbstractRDFHandler() {
+
+				@Override
+				public void handleStatement(Statement st)
+					throws RDFHandlerException
+				{
+					if(st.getContext() == null){
+						assertThat(st, is((equalTo(vf.createStatement(micah, lname, micahlname, null)))));
+					}
+					else {
+						if(st.getContext().equals(dirgraph1)){
+							assertThat(st, is((equalTo(st2))));
+						}
+									
+						else{
+							fail("Statement not returned");
+						}
+					}
+					
+				}
+			},dirgraph1,  null);
+
+		}
+		
+		catch(Exception ex){
+			logger.error("Failed :", ex);
+		}
+   }
+   
+   @Test
+	public void testAddStatements() throws Exception{
+
+		Statement st1 = vf.createStatement(john, fname, johnfname, dirgraph);
+		Statement st2 = vf.createStatement(john, homeTel, johnhomeTel, dirgraph1);
+		Statement st3 = vf.createStatement(micah, lname, micahlname,dirgraph);
+				
+		testAdminCon.add(st1, dirgraph1);
+		testAdminCon.add(st2, dirgraph);
+		testAdminCon.add(st3,(Resource)null);
+
+
+
+		try{
+			Assert.assertEquals(3, testAdminCon.size());
+			
+			testWriterCon.exportStatements(null, null, null, false, new AbstractRDFHandler() {
+
+				@Override
+				public void handleStatement(Statement st)
+					throws RDFHandlerException
+				{
+					if(st.getContext() == null){
+						assertThat(st, is((equalTo(vf.createStatement(micah, lname, micahlname, null)))));
+					}
+					else {
+						if(st.getContext().equals(dirgraph)){
+							assertThat(st, is(not(equalTo(vf.createStatement(john, homeTel, johnhomeTel, dirgraph)))));
+				
+						}
+						else if(st.getContext().equals(dirgraph1)){
+							assertThat(st, is((equalTo(vf.createStatement(john, fname, johnfname, dirgraph1)))));
+						
+						}
+					
+						else{
+							fail("Statement not returned");
+						}
+					}
+					
+				}
+			},dirgraph, dirgraph1, null);
+			
+			
+		}
+		
+		catch(Exception ex){
+			logger.error("Failed :", ex);
+		}
+  }
+  
 }

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
@@ -550,10 +551,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public RepositoryResult<Statement> getStatements(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts) throws RepositoryException {
-        if (contexts == null) {
-            contexts = new Resource[] { null };
-        }
-        try {
+    	contexts = verifyContextNotNull(contexts);
+    	try {
             if (isQuadMode()) {
                 StringBuilder sb = new StringBuilder();
                 sb.append("SELECT * WHERE { GRAPH ?ctx { ?s ?p ?o } filter (?ctx = (");
@@ -647,13 +646,12 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
     public boolean hasStatement(Resource subject, IRI predicate, Value object, boolean includeInferred, Resource... contexts) throws RepositoryException {
         if(!this.isOpen()){throw new RepositoryException("Connection is closed.");}
         String queryString = null;
-        if(contexts == null) {
-            queryString="ASK { GRAPH ?ctx { ?s ?p ?o } filter (?ctx = (IRI(\""+DEFAULT_GRAPH_URI+"\")))}";
-        }else if (contexts.length == 0) {
+        contexts = verifyContextNotNull(contexts);
+    	if (contexts.length == 0) {
             queryString = SOMETHING;
         }
-        else {
-            StringBuilder sb= new StringBuilder();
+    	else{
+    		StringBuilder sb= new StringBuilder();
             sb.append("ASK { GRAPH ?ctx { ?s ?p ?o } filter (?ctx = (");
             boolean first = true;
             for (Resource context : contexts) {
@@ -766,9 +764,7 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public long size(Resource... contexts) throws RepositoryException {
-        if (contexts == null) {
-            contexts = new Resource[] { null };
-        }
+    	contexts = verifyContextNotNull(contexts);
         try {
             StringBuilder sb = new StringBuilder();
             sb.append("SELECT (count(?s) as ?ct) where { GRAPH ?g { ?s ?p ?o }");
@@ -939,7 +935,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(InputStream in, String baseURI, RDFFormat dataFormat, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
-        getClient().sendAdd(in, baseURI, dataFormat, contexts);
+    	contexts = verifyContextNotNull(contexts);
+    	getClient().sendAdd(in, baseURI, dataFormat, contexts);
     }
 
     /**
@@ -957,7 +954,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(File file, String baseURI, RDFFormat dataFormat, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
-        if(notNull(baseURI)) {
+        contexts = verifyContextNotNull(contexts);
+	 	if(notNull(baseURI)) {
             getClient().sendAdd(file, baseURI, dataFormat, contexts);
         }else{
             getClient().sendAdd(file, file.toURI().toString(), dataFormat, contexts);
@@ -977,7 +975,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(Reader reader, String baseURI, RDFFormat dataFormat, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
-        getClient().sendAdd(reader, baseURI, dataFormat, contexts);
+    	contexts = verifyContextNotNull(contexts);
+    	getClient().sendAdd(reader, baseURI, dataFormat, contexts);
     }
 
     /**
@@ -995,11 +994,12 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(URL url, String baseURI, RDFFormat dataFormat, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
-        if(notNull(baseURI)) {
+    	contexts = verifyContextNotNull(contexts);
+	  	if(notNull(baseURI)) {
             getClient().sendAdd(new URL(url.toString()).openStream(), baseURI, dataFormat, contexts);
         }else{
             getClient().sendAdd(new URL(url.toString()).openStream(), url.toString(), dataFormat, contexts);
-        }
+        }    
     }
 
     /**
@@ -1013,7 +1013,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(Resource subject, IRI predicate, Value object, Resource... contexts) throws RepositoryException {
-        getClient().sendAdd(null, subject, predicate, object, contexts);
+    	contexts = verifyContextNotNull(contexts);
+		getClient().sendAdd(null, subject, predicate, object, contexts);
     }
 
     /**
@@ -1025,7 +1026,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(Statement st, Resource... contexts) throws RepositoryException {
-        add(st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
+    	contexts = verifyContextNotNull(contexts);
+		add(st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
     }
 
     /**
@@ -1037,12 +1039,13 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void add(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
-        Iterator <? extends Statement> iter = statements.iterator();
-        while(iter.hasNext()){
-            Statement st = iter.next();
-            add(st, mergeResource(st.getContext(), contexts));
-        }
-    }
+    	contexts = verifyContextNotNull(contexts);
+    	Iterator <? extends Statement> iter = statements.iterator();
+	    while(iter.hasNext()){
+	    	Statement st = iter.next();
+	        add(st, mergeResource(st.getContext(), contexts));
+	    }
+	}
 
     /**
      * add triple statements
@@ -1055,11 +1058,12 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public <E extends Exception> void add(Iteration<? extends Statement, E> statements, Resource... contexts) throws RepositoryException, E {
-        while(statements.hasNext()){
+    	contexts = verifyContextNotNull(contexts);
+		while(statements.hasNext()){
             Statement st = statements.next();
             add(st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
         }
-    }
+	}
 
 
     /**
@@ -1073,7 +1077,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void remove(Resource subject, IRI predicate, Value object, Resource... contexts) throws RepositoryException {
-        getClient().sendRemove(null, subject, predicate, object, contexts);
+    	contexts = verifyContextNotNull(contexts);
+    	getClient().sendRemove(null, subject, predicate, object, contexts);
     }
 
     /**
@@ -1085,7 +1090,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void remove(Statement st, Resource... contexts) throws RepositoryException {
-        getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
+    	contexts = verifyContextNotNull(contexts);
+    	getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
     }
 
     /**
@@ -1112,12 +1118,13 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public void remove(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
-        Iterator <? extends Statement> iter = statements.iterator();
-        while(iter.hasNext()){
-            Statement st = iter.next();
-            getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
-        }
-    }
+    	contexts = verifyContextNotNull(contexts);
+	    Iterator <? extends Statement> iter = statements.iterator();
+	    while(iter.hasNext()){
+	    	Statement st = iter.next();
+	        getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
+	     }
+	}
 
     /**
      * remove triple statements
@@ -1146,11 +1153,12 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     public <E extends Exception> void remove(Iteration<? extends Statement, E> statements, Resource... contexts) throws RepositoryException, E {
-        while(statements.hasNext()){
+    	contexts = verifyContextNotNull(contexts);
+	 	while(statements.hasNext()){
             Statement st = statements.next();
             getClient().sendRemove(null, st.getSubject(), st.getPredicate(), st.getObject(), mergeResource(st.getContext(), contexts));
         }
-    }
+	}
 
     /**
      * add without commit
@@ -1165,7 +1173,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     protected void addWithoutCommit(Resource subject, IRI predicate, Value object, Resource... contexts) throws RepositoryException {
-        add(subject, predicate, object, contexts);
+    	contexts = verifyContextNotNull(contexts);
+    	add(subject, predicate, object, contexts); 
     }
 
     /**
@@ -1181,7 +1190,8 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      */
     @Override
     protected void removeWithoutCommit(Resource subject, IRI predicate, Value object, Resource... contexts) throws RepositoryException {
-        remove(subject, predicate, object, contexts);
+    	contexts = verifyContextNotNull(contexts);
+    	remove(subject, predicate, object, contexts);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -1376,21 +1386,24 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
         if (obj != null) {
             query.setBinding("o", obj);
         }
-        if (contexts != null && contexts.length > 0) {
-            SimpleDataset dataset = new SimpleDataset();
-            if(notNull(contexts)){
-                for (Resource context : contexts) {
-                    if (notNull(context) || context instanceof IRI) {
+        contexts = verifyContextNotNull(contexts);
+        SimpleDataset dataset = new SimpleDataset();
+        if(contexts.length > 0){
+            for (Resource context : contexts) {
+            	if(notNull(context)){
+            		if (context instanceof IRI) {
                         dataset.addDefaultGraph((IRI) context);
-                    } else {
-                        dataset.addDefaultGraph(getValueFactory().createIRI(DEFAULT_GRAPH_URI));
                     }
-                }
-            }else{
-                dataset.addDefaultGraph(getValueFactory().createIRI(DEFAULT_GRAPH_URI));
+            	}
+            	else{
+            		 dataset.addDefaultGraph(getValueFactory().createIRI(DEFAULT_GRAPH_URI));
+            	}
             }
-            query.setDataset(dataset);
         }
+        else {
+            dataset.addDefaultGraph(getValueFactory().createIRI(DEFAULT_GRAPH_URI));
+        }
+        query.setDataset(dataset);
     }
 
     /**
@@ -1409,18 +1422,13 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
      * @param arr
      * @return
      */
-    private static Resource[] mergeResource(Resource o, Resource... arr) {
-        if(arr != null && arr.length > 0){
-            return arr;
-        } else if(o == null) {
-            return null;
-        } else {
-            Resource[] newArray = new Resource[1];
-            newArray[0] = o;
-            return newArray;
-        }
-
-    }
+    private static Resource[] mergeResource(Resource o, Resource... arr) throws RepositoryException {
+    	arr = verifyContextNotNull(arr);
+    	if (arr.length == 0 && o != null) {
+			arr = new Resource[] { o };
+		}
+		return arr;          
+   }
 
     /**
      * convert bindings
@@ -1440,7 +1448,7 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
                 Value o = obj==null ? b.getValue("o") : obj;
                 IRI ctx = (IRI)b.getValue("ctx");
                 if (ctx.stringValue().equals(DEFAULT_GRAPH_URI)) {
-                    ctx = null;
+                    ctx = (IRI) null;
                 }
                 return getValueFactory().createStatement(s, p, o, ctx);
             }
@@ -1457,6 +1465,24 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
     private static Boolean notNull(Object item) {
         return item!=null;
     }
+    
+	/**
+	 * private utility method that verifies that the supplied contexts parameter is not <tt>null</tt>, throwing an
+	 * {@link IllegalArgumentException} if it is.
+	 * 
+	 * @param contexts
+	 *        The parameter to check.
+	 * @return Resource[] 
+	 * @throws IllegalArgumentException
+	 *         If the supplied contexts parameter is <tt>null</tt>.
+	 */
+	private static Resource[] verifyContextNotNull(Resource... contexts) {
+		if (contexts == null) {
+			throw new IllegalArgumentException(
+					"Illegal value null array for contexts argument; either the value should be cast to Resource or an empty array should be supplied");
+		}
+		return Arrays.copyOf(contexts, contexts.length);
+	}
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
@@ -19,18 +19,44 @@
  */
 package com.marklogic.semantics.rdf4j;
 
-import com.marklogic.client.query.QueryDefinition;
-import com.marklogic.client.semantics.GraphPermissions;
-import com.marklogic.client.semantics.SPARQLRuleset;
-import com.marklogic.semantics.rdf4j.query.*;
-import com.marklogic.semantics.rdf4j.client.MarkLogicClient;
+import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Iterator;
+
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.iteration.*;
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.ConvertingIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
+import org.eclipse.rdf4j.common.iteration.Iteration;
+import org.eclipse.rdf4j.common.iteration.SingletonIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.StatementImpl;
-import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.UnsupportedQueryLanguageException;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -46,15 +72,15 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Iterator;
-
-import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
+import com.marklogic.client.query.QueryDefinition;
+import com.marklogic.client.semantics.GraphPermissions;
+import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.rdf4j.client.MarkLogicClient;
+import com.marklogic.semantics.rdf4j.query.MarkLogicBooleanQuery;
+import com.marklogic.semantics.rdf4j.query.MarkLogicGraphQuery;
+import com.marklogic.semantics.rdf4j.query.MarkLogicQuery;
+import com.marklogic.semantics.rdf4j.query.MarkLogicTupleQuery;
+import com.marklogic.semantics.rdf4j.query.MarkLogicUpdateQuery;
 
 /**
  * RepositoryConnection to MarkLogic triplestore

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
@@ -27,9 +27,11 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import com.marklogic.client.*;
-import com.marklogic.semantics.rdf4j.MarkLogicRdf4jException;
-import org.eclipse.rdf4j.model.*;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sparql.query.SPARQLQueryBindingSet;
@@ -39,6 +41,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.ForbiddenUserException;
+import com.marklogic.client.Transaction;
 import com.marklogic.client.impl.SPARQLBindingsImpl;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.InputStreamHandle;
@@ -50,6 +57,7 @@ import com.marklogic.client.semantics.SPARQLBindings;
 import com.marklogic.client.semantics.SPARQLQueryDefinition;
 import com.marklogic.client.semantics.SPARQLQueryManager;
 import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.semantics.rdf4j.MarkLogicRdf4jException;
 
 /**
  * internal class for interacting with java api client
@@ -388,12 +396,14 @@ class MarkLogicClientImpl {
         StringBuilder sb = new StringBuilder();
         String[] contextArgs = null;
         if(contexts.length>0)
-        {
-            if (notNull(baseURI))sb.append("BASE <" + baseURI + ">\n");
+        {	if (notNull(baseURI))sb.append("BASE <" + baseURI + ">\n");
             contextArgs = new String[contexts.length];
             for (int i = 0; i < contexts.length; i++) {
                 if(notNull(contexts[i])){
                     contextArgs[i] = contexts[i].stringValue();
+                }
+                else{
+                	contextArgs[i] = DEFAULT_GRAPH_URI;
                 }
             }
         }

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
@@ -279,7 +279,7 @@ class MarkLogicClientImpl {
             if (dataFormat.equals(RDFFormat.NQUADS) || dataFormat.equals(RDFFormat.TRIG)) {
                 graphManager.mergeGraphs(new FileHandle(file),tx);
             } else {
-                if (notNull(contexts) && contexts.length>0) {
+                if (contexts.length>0) {
                     for (int i = 0; i < contexts.length; i++) {
                         if(notNull(contexts[i])){
                             graphManager.mergeAs(contexts[i].toString(), new FileHandle(file), getGraphPerms(),tx);
@@ -313,7 +313,7 @@ class MarkLogicClientImpl {
             if (dataFormat.equals(RDFFormat.NQUADS) || dataFormat.equals(RDFFormat.TRIG)) {
                 graphManager.mergeGraphs(new InputStreamHandle(in),tx);
             } else {
-                if (notNull(contexts) && contexts.length > 0) {
+                if (contexts.length > 0) {
                     for (int i = 0; i < contexts.length; i++) {
                         if (notNull(contexts[i])) {
                             graphManager.mergeAs(contexts[i].toString(), new InputStreamHandle(in), getGraphPerms(), tx);
@@ -348,7 +348,7 @@ class MarkLogicClientImpl {
      */
     public void performAdd(String baseURI, Resource subject, IRI predicate, Value object, Transaction tx, Resource... contexts) throws MarkLogicRdf4jException {
         StringBuilder sb = new StringBuilder();
-        if(notNull(contexts) && contexts.length>0) {
+        if(contexts.length>0) {
             if (notNull(baseURI)) sb.append("BASE <" + baseURI + ">\n");
             sb.append("INSERT DATA { ");
             for (int i = 0; i < contexts.length; i++) {
@@ -361,7 +361,7 @@ class MarkLogicClientImpl {
             sb.append("}");
         } else {
             sb.append("INSERT DATA { GRAPH <" + DEFAULT_GRAPH_URI + "> {?s ?p ?o .}}");
-        }
+        }  
         SPARQLQueryDefinition qdef = sparqlManager.newQueryDefinition(sb.toString());
         if (notNull(ruleset) ) {qdef.setRulesets(ruleset);}
         if(notNull(graphPerms)){ qdef.setUpdatePermissions(graphPerms);}
@@ -387,7 +387,7 @@ class MarkLogicClientImpl {
     public void performRemove(String baseURI, Resource subject, IRI predicate, Value object, Transaction tx, Resource... contexts) throws MarkLogicRdf4jException {
         StringBuilder sb = new StringBuilder();
         String[] contextArgs = null;
-        if(notNull(contexts) && contexts.length>0)
+        if(contexts.length>0)
         {
             if (notNull(baseURI))sb.append("BASE <" + baseURI + ">\n");
             contextArgs = new String[contexts.length];
@@ -414,7 +414,7 @@ class MarkLogicClientImpl {
      * @param contexts
      */
     public void performClear(Transaction tx, Resource... contexts) {
-        if(notNull(contexts)) {
+        if(contexts.length>0) {
             for (int i = 0; i < contexts.length; i++) {
                 if (notNull(contexts[i])) {
                     graphManager.delete(contexts[i].stringValue(), tx);


### PR DESCRIPTION
For fixing issue RDF4J-26. The fix throws IllegalArgumentException  when null is passed as context. example: con.add(st, null)