### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# marklogic-rdf4j v1.0.0
+# marklogic-rdf4j v1.1.0
 
 ## Introduction
 
@@ -28,13 +28,13 @@ server.
 ### Quick Start
 
 The markLogic-rdf4j API is available via [Maven
-Central](http://central.maven.org/maven2/artifact/com.marklogic/marklogic-rdf4j/1.0.0).
+Central](http://central.maven.org/maven2/artifact/com.marklogic/marklogic-rdf4j/1.1.0).
 
 For gradle projects, include the following dependency in your `build.gradle`:
 
 ```
 dependencies {
-    compile group: 'com.marklogic', name: 'marklogic-rdf4j', version: '1.0.0'
+    compile group: 'com.marklogic', name: 'marklogic-rdf4j', version: '1.1.0'
 }
 ```
 
@@ -44,7 +44,7 @@ For maven projects, include in your pom.xml:
 <dependency>
     <groupId>com.marklogic</groupId>
     <artifactId>marklogic-rdf4j</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -55,7 +55,7 @@ This section describes how to build and test marklogic-rdf4j API from _develop_ 
 #### Setup MarkLogic Java API Client (optional)
 
 marklogic-rdf4j depends on 
-[MarkLogic Java API Client v4.0-1](http://mvnrepository.com/artifact/com.marklogic/marklogic-client-api/4.0.1)
+[MarkLogic Java API Client v4.0-2](http://mvnrepository.com/artifact/com.marklogic/marklogic-client-api/4.0.2)
 and should pull down this version from maven central.
 
 To optionally build marklogic-rdf4j with _develop_ branch version of MarkLogic Java API Client:
@@ -108,7 +108,7 @@ optionally you can build the jar without running tests.
 gradle build -x test
 ```
 
-and copy resultant build/lib/marklogic-rdf4j-1.0.0.jar.
+and copy resultant build/lib/marklogic-rdf4j-1.1.0.jar.
 
 ### Examples
 

--- a/marklogic-rdf4j-examples/gradle.properties
+++ b/marklogic-rdf4j-examples/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=1.0.0
+version=1.1.0
 
 # properties for test deployment
 mlAppName=marklogic-rdf4j-test

--- a/marklogic-rdf4j-performance/gradle.properties
+++ b/marklogic-rdf4j-performance/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=1.0.0
+version=1.1.0
 
 # properties for performance deployment
 mlAppName=marklogic-rdf4j-perf-test

--- a/marklogic-rdf4j/gradle.properties
+++ b/marklogic-rdf4j/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=1.0.0
+version=1.1.0
 
 publishUrl=file:../marklogic-rdf4j/releases
 

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import com.marklogic.client.Transaction;
 import com.marklogic.semantics.rdf4j.utils.Util;
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
@@ -1434,6 +1435,11 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
             dataset.addDefaultGraph(getValueFactory().createIRI(DEFAULT_GRAPH_URI));
         }
         query.setDataset(dataset);
+    }
+
+    public Transaction getTransaction()
+    {
+        return this.client.getTransaction();
     }
 
     /**

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnection.java
@@ -730,7 +730,7 @@ public class MarkLogicRepositoryConnection extends AbstractRepositoryConnection 
     // TBD- should refactor
     @Override
     public void export(RDFHandler handler, Resource... contexts) throws RepositoryException, RDFHandlerException {
-        exportStatements(null, null, null, true, handler);
+        exportStatements(null, null, null, false, handler, contexts);
     }
 
     /**

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClient.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClient.java
@@ -77,9 +77,9 @@ public class MarkLogicClient {
 
 	private Transaction tx = null;
 
-    private SPARQLRuleset[] defaultRulesets;
+	private SPARQLRuleset[] defaultRulesets;
 
-    private TripleWriteCache timerWriteCache;
+	private TripleWriteCache timerWriteCache;
 	private Timer writeTimer;
 	private TripleDeleteCache timerDeleteCache;
 	private Timer deleteTimer;
@@ -464,7 +464,11 @@ public class MarkLogicClient {
 		return this.tx != null;
 	}
 
-	/**
+	public Transaction getTransaction() {
+        return tx;
+    }
+
+    /**
 	 * sets transaction (tx) to null
 	 *
 	 * @throws MarkLogicTransactionException

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
@@ -24,9 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.security.KeyManagementException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -46,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.Transaction;

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTransactionTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTransactionTest.java
@@ -220,8 +220,13 @@ public class MarkLogicRepositoryTransactionTest extends Rdf4jTestBase {
         handle.setFormat(Format.XML);
         docMgr.write(docId, handle, conn.getTransaction());
         DocumentDescriptor documentDescriptor = docMgr.exists(docId, conn.getTransaction());
+
         Assert.assertEquals(docId, documentDescriptor.getUri());
         Assert.assertNull(docMgr.exists(docId));
+
         conn.rollback();
+
+        Assert.assertNull(conn.getTransaction());
+        Assert.assertNull(docMgr.exists(docId));
     }
 }

--- a/marklogic-rdf4j/src/test/resources/testdata/bbq1.xml
+++ b/marklogic-rdf4j/src/test/resources/testdata/bbq1.xml
@@ -1,0 +1,9 @@
+<entry xmlns="http://example.com" date="2007-10-31T14:17:44.425-07:00">
+   <title>Sally's Southern BBQ</title>
+   <abstract>A classic southern recipe</abstract>
+   <flavor-descriptor>cayanne</flavor-descriptor>
+   <flavor-descriptor>molasses</flavor-descriptor>
+   <flavor-descriptor>smoky</flavor-descriptor>
+   <scoville>800</scoville>
+   <rating>3.0</rating>
+</entry>


### PR DESCRIPTION
Version update from 1.0.0 to 1.1.0
Expose Transaction object.
Fixes #18 export now uses the supplied contexts and returns only explicit statements.